### PR TITLE
De/select annotation via map for show/hideCallout

### DIFF
--- a/ios/AirMaps/AIRMapMarker.m
+++ b/ios/AirMaps/AIRMapMarker.m
@@ -134,8 +134,6 @@
 {
     MKAnnotationView *annotationView = [self getAnnotationView];
 
-    [self setSelected:YES animated:NO];
-
     id event = @{
             @"action": @"marker-select",
             @"id": self.identifier ?: @"unknown",
@@ -167,8 +165,6 @@
 {
     // hide the callout view
     [self.map.calloutView dismissCalloutAnimated:YES];
-
-    [self setSelected:NO animated:NO];
 
     id event = @{
             @"action": @"marker-deselect",

--- a/ios/AirMaps/AIRMapMarkerManager.m
+++ b/ios/AirMaps/AIRMapMarkerManager.m
@@ -60,7 +60,8 @@ RCT_EXPORT_METHOD(showCallout:(nonnull NSNumber *)reactTag)
         if (![view isKindOfClass:[AIRMapMarker class]]) {
             RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
         } else {
-            [(AIRMapMarker *) view showCalloutView];
+            AIRMapMarker *marker = (AIRMapMarker *)view;
+            [marker.map selectAnnotation:marker animated:NO];
         }
     }];
 }
@@ -72,7 +73,8 @@ RCT_EXPORT_METHOD(hideCallout:(nonnull NSNumber *)reactTag)
         if (![view isKindOfClass:[AIRMapMarker class]]) {
             RCTLogError(@"Invalid view returned from registry, expecting AIRMap, got: %@", view);
         } else {
-            [(AIRMapMarker *) view hideCalloutView];
+            AIRMapMarker *marker = (AIRMapMarker *)view;
+            [marker.map deselectAnnotation:marker animated:NO];
         }
     }];
 }


### PR DESCRIPTION
Problem: This means that if an annotation is displayed by calling
showCallout(), it can't be deselected by tapping away on the map. It
can only be dismissed by explicitly calling hideCallout().

Analysis: When showCallout() is called on an annotation, it isn't
displayed through the map via selectAnnotation:. As a result, the
annotation is never deselected (and the didDeselectAnnotationView:
delegate method is never called), because the map didn't know it was
selected in the first place.

Fix:
- In showCallout()/hideCallout(), use
  selectAnnotation:/deselectAnnotation: through the map.
- In showCalloutView:/hideCalloutView:, don't call setSelected: on the
  MKAnnotationView. Quoting from the link below: "You should not call
  this method directly. An MKMapView object calls this method in
  response to user interactions with the annotation."

References:
- https://developer.apple.com/library/prerelease/ios/documentation/MapKit/Reference/MKAnnotationView_Class/index.html#//apple_ref/occ/instm/MKAnnotationView/setSelected:animated:
